### PR TITLE
PA-108 - [BE] - criar rota de cadastro de usuário

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
 	<description>software para projeto integrador</description>
 	<properties>
 		<java.version>11</java.version>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
 	</properties>
 
 
@@ -115,6 +117,12 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.7.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -122,6 +130,14 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>10</source>
+					<target>10</target>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -15,23 +15,16 @@
 	<description>software para projeto integrador</description>
 	<properties>
 		<java.version>11</java.version>
-		<maven.compiler.source>8</maven.compiler.source>
-		<maven.compiler.target>8</maven.compiler.target>
 	</properties>
-
-
 	<dependencies>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-cache</artifactId>
 		</dependency>
-
 		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -39,22 +32,18 @@
 			<version>1.18.20</version>
 			<scope>provided</scope>
 		</dependency>
-
 		<!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api -->
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-api</artifactId>
 			<version>0.11.2</version>
 		</dependency>
-
-
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-jackson</artifactId> <!-- or jjwt-gson if Gson is preferred -->
 			<version>0.11.1</version>
 			<scope>runtime</scope>
 		</dependency>
-
 		<!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-impl -->
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
@@ -63,13 +52,21 @@
 			<scope>runtime</scope>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/io.springfox/springfox-swagger2 -->
 		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger2</artifactId>
+			<version>3.0.0</version>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-ui</artifactId>
 			<version>1.5.10</version>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui -->
 		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>3.0.0</version>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-security</artifactId>
 			<version>1.5.10</version>
@@ -79,12 +76,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
@@ -93,20 +88,16 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-
-
 		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
 			<version>9.4.0.jre11</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -117,29 +108,13 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.7.2</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>10</source>
-					<target>10</target>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,32 @@
 	<properties>
 		<java.version>11</java.version>
 	</properties>
+
 	<dependencies>
+
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
@@ -51,27 +76,16 @@
 			<version>0.11.2</version>
 			<scope>runtime</scope>
 		</dependency>
-
-		<!-- https://mvnrepository.com/artifact/io.springfox/springfox-swagger2 -->
 		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger2</artifactId>
-			<version>3.0.0</version>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-ui</artifactId>
 			<version>1.5.10</version>
 		</dependency>
-
-		<!-- https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui -->
 		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger-ui</artifactId>
-			<version>3.0.0</version>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-security</artifactId>
 			<version>1.5.10</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -108,7 +122,13 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/src/main/java/br/com/pucgo/perguntaai/config/security/SecurityConfigurations.java
+++ b/src/main/java/br/com/pucgo/perguntaai/config/security/SecurityConfigurations.java
@@ -70,6 +70,7 @@ public class SecurityConfigurations extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.GET, "/api/v1/topics/**").permitAll()
                 .antMatchers(HttpMethod.POST, "/api/v1/topics").permitAll()
                 .antMatchers(HttpMethod.POST, "/api/v1/auth").permitAll()
+                .antMatchers(HttpMethod.POST, "/api/v1/user").permitAll()
                 .antMatchers("/h2-console/**").permitAll()
                 .antMatchers(AUTH_WHITELIST).permitAll()
                 .antMatchers(HttpMethod.GET, "/actuator/**").permitAll()

--- a/src/main/java/br/com/pucgo/perguntaai/controllers/v1/UserController.java
+++ b/src/main/java/br/com/pucgo/perguntaai/controllers/v1/UserController.java
@@ -1,0 +1,46 @@
+package br.com.pucgo.perguntaai.controllers.v1;
+
+import br.com.pucgo.perguntaai.config.security.TokenService;
+import br.com.pucgo.perguntaai.models.DTO.TokenDto;
+import br.com.pucgo.perguntaai.models.DTO.UserDto;
+import br.com.pucgo.perguntaai.models.User;
+import br.com.pucgo.perguntaai.models.form.LoginForm;
+import br.com.pucgo.perguntaai.models.form.UserForm;
+import br.com.pucgo.perguntaai.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.transaction.Transactional;
+import javax.validation.Valid;
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/user")
+public class UserController {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @PostMapping
+    @Transactional
+    @CacheEvict(value = "user", allEntries = true)
+    public ResponseEntity<UserDto> register(@RequestBody @Valid UserForm userForm,
+                                            UriComponentsBuilder uriBuilder) {
+        User user = userForm.convert();
+        userRepository.save(user);
+
+        URI uri = uriBuilder.path("/api/v1/user/register/{id}").buildAndExpand(user.getId()).toUri();
+        return ResponseEntity.created(uri).body(new UserDto(user));
+    }
+}
+

--- a/src/main/java/br/com/pucgo/perguntaai/controllers/v1/UserController.java
+++ b/src/main/java/br/com/pucgo/perguntaai/controllers/v1/UserController.java
@@ -39,7 +39,7 @@ public class UserController {
         User user = userForm.convert();
         userRepository.save(user);
 
-        URI uri = uriBuilder.path("/api/v1/user/register/{id}").buildAndExpand(user.getId()).toUri();
+        URI uri = uriBuilder.path("/register/{id}").buildAndExpand(user.getId()).toUri();
         return ResponseEntity.created(uri).body(new UserDto(user));
     }
 }

--- a/src/main/java/br/com/pucgo/perguntaai/models/DTO/UserDto.java
+++ b/src/main/java/br/com/pucgo/perguntaai/models/DTO/UserDto.java
@@ -1,0 +1,21 @@
+package br.com.pucgo.perguntaai.models.DTO;
+
+
+import br.com.pucgo.perguntaai.models.User;
+
+public class UserDto {
+    private Long id;
+    private String name;
+    private String email;
+    private String password;
+    private String course;
+
+
+    public UserDto(User user) {
+        this.id = user.getId();
+        this.name = user.getName();
+        this.email = user.getEmail();
+        this.password = user.getPassword();
+        this.course = user.getCourse();
+    }
+}

--- a/src/main/java/br/com/pucgo/perguntaai/models/DTO/UserDto.java
+++ b/src/main/java/br/com/pucgo/perguntaai/models/DTO/UserDto.java
@@ -2,7 +2,9 @@ package br.com.pucgo.perguntaai.models.DTO;
 
 
 import br.com.pucgo.perguntaai.models.User;
+import lombok.Getter;
 
+@Getter
 public class UserDto {
     private Long id;
     private String name;

--- a/src/main/java/br/com/pucgo/perguntaai/models/DTO/UserDto.java
+++ b/src/main/java/br/com/pucgo/perguntaai/models/DTO/UserDto.java
@@ -4,6 +4,8 @@ package br.com.pucgo.perguntaai.models.DTO;
 import br.com.pucgo.perguntaai.models.User;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class UserDto {
     private Long id;
@@ -11,6 +13,7 @@ public class UserDto {
     private String email;
     private String password;
     private String course;
+    private LocalDateTime creationDate;
 
 
     public UserDto(User user) {
@@ -19,5 +22,6 @@ public class UserDto {
         this.email = user.getEmail();
         this.password = user.getPassword();
         this.course = user.getCourse();
+        this.creationDate = user.getCreationDate();
     }
 }

--- a/src/main/java/br/com/pucgo/perguntaai/models/User.java
+++ b/src/main/java/br/com/pucgo/perguntaai/models/User.java
@@ -43,9 +43,9 @@ public class User implements UserDetails {
     @Column(name = "role_user")
     @Enumerated(EnumType.STRING)
     private RoleUser roleUser;
-
     @ManyToMany(fetch = FetchType.EAGER)
     private List<Profile> profiles = new ArrayList<>();
+    private LocalDateTime creationDate = LocalDateTime.now();
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/br/com/pucgo/perguntaai/models/User.java
+++ b/src/main/java/br/com/pucgo/perguntaai/models/User.java
@@ -20,6 +20,7 @@ import java.util.List;
 @NoArgsConstructor
 @EqualsAndHashCode
 @Entity
+@Builder
 @Table(name = "TB_USER")
 public class User implements UserDetails {
     @Id
@@ -74,5 +75,12 @@ public class User implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    public User(String name, String email, String course, String password) {
+        this.name = name;
+        this.email = email;
+        this.course = course;
+        this.password = password;
     }
 }

--- a/src/main/java/br/com/pucgo/perguntaai/models/form/UserForm.java
+++ b/src/main/java/br/com/pucgo/perguntaai/models/form/UserForm.java
@@ -1,0 +1,30 @@
+package br.com.pucgo.perguntaai.models.form;
+
+import br.com.pucgo.perguntaai.models.User;
+import com.sun.istack.NotNull;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotEmpty;
+
+public class UserForm {
+    @NotNull
+    @NotEmpty
+    @Length(min = 6)
+    private String name;
+    @NotNull
+    @NotEmpty
+    @Length(min = 10)
+    private String email;
+    @NotNull
+    @NotEmpty
+    @Length(min = 3)
+    private String password;
+    @NotNull
+    @NotEmpty
+    @Length(min = 3)
+    private String course;
+
+    public User convert() {
+        return new User(name, email, course, password);
+    }
+}

--- a/src/main/java/br/com/pucgo/perguntaai/models/form/UserForm.java
+++ b/src/main/java/br/com/pucgo/perguntaai/models/form/UserForm.java
@@ -2,10 +2,13 @@ package br.com.pucgo.perguntaai.models.form;
 
 import br.com.pucgo.perguntaai.models.User;
 import com.sun.istack.NotNull;
+import lombok.Builder;
+import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotEmpty;
-
+@Getter
+@Builder
 public class UserForm {
     @NotNull
     @NotEmpty

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.port=8081
-spring.profiles.active=test
+spring.profiles.active=prod
 spring.jpa.open-in-view=true
 springdoc.swagger-ui.path=/api-pergunta-ai.html
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.port=8081
-spring.profiles.active=prod
+spring.profiles.active=test
 spring.jpa.open-in-view=true
 springdoc.swagger-ui.path=/api-pergunta-ai.html
 

--- a/src/test/java/br/com/pucgo/perguntaai/Controllers/RegisterUserTests.java
+++ b/src/test/java/br/com/pucgo/perguntaai/Controllers/RegisterUserTests.java
@@ -1,0 +1,47 @@
+package br.com.pucgo.perguntaai.Controllers;
+
+import br.com.pucgo.perguntaai.controllers.v1.UserController;
+import br.com.pucgo.perguntaai.models.DTO.UserDto;
+import br.com.pucgo.perguntaai.models.User;
+import br.com.pucgo.perguntaai.models.form.UserForm;
+import br.com.pucgo.perguntaai.repositories.UserRepository;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class RegisterUserTests {
+    @Mock
+    private UserRepository userRepository;
+    @InjectMocks
+    private UserController userController;
+    @Test
+    void mustResgisterUser() {
+        final UserForm registerUserForm = UserForm.builder()
+                .name("Aluno Teste")
+                .email("alunoteste@puc.com.br")
+                .course("ADS")
+                .password("123456")
+                .build();
+
+        User registerUser = registerUserForm.convert();
+
+        when(userRepository.save(ArgumentMatchers.any(User.class))).thenReturn(registerUser);
+
+        UriComponentsBuilder uriComponents = UriComponentsBuilder.fromUriString("localhost:8081/api/v1/user/register/{id}");
+
+        ResponseEntity<?> userCreated = userController.register(registerUserForm, uriComponents);
+        assertNotNull(userCreated);
+    }
+}

--- a/src/test/java/br/com/pucgo/perguntaai/PerguntaaiBackendApplicationTests.java
+++ b/src/test/java/br/com/pucgo/perguntaai/PerguntaaiBackendApplicationTests.java
@@ -1,27 +1,49 @@
 package br.com.pucgo.perguntaai;
 
+import br.com.pucgo.perguntaai.controllers.v1.UserController;
+import br.com.pucgo.perguntaai.models.DTO.UserDto;
 import br.com.pucgo.perguntaai.models.User;
+import br.com.pucgo.perguntaai.models.form.UserForm;
 import br.com.pucgo.perguntaai.repositories.UserRepository;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class PerguntaaiBackendApplicationTests {
 
-	UserRepository userRepository;
+	@Mock
+	private UserRepository userRepository;
+	@InjectMocks
+	private UserController userController;
 	@Test
 	void mustResgisterUser() {
-		final User registerUser = User.builder()
+		final UserForm registerUserForm = UserForm.builder()
 				.name("Aluno Teste")
 				.email("alunoteste@puc.com.br")
 				.course("ADS")
 				.password("123456")
 				.build();
 
-		userRepository.save(registerUser);
-		assertNotNull(userRepository);
+		User registerUser = registerUserForm.convert();
+
+		when(userRepository.save(ArgumentMatchers.any(User.class))).thenReturn(registerUser);
+
+
+		UriComponentsBuilder uriComponents = UriComponentsBuilder.fromUriString("localhost:8081/api/v1/user/register/{id}");
+
+		ResponseEntity<UserDto> userCreated = userController.register(registerUserForm, uriComponents);
+		assertThat(userCreated.getBody().getName()).isSameAs(registerUserForm.getName());
+		assertNotNull(userCreated);
 	}
 
 }

--- a/src/test/java/br/com/pucgo/perguntaai/PerguntaaiBackendApplicationTests.java
+++ b/src/test/java/br/com/pucgo/perguntaai/PerguntaaiBackendApplicationTests.java
@@ -1,13 +1,27 @@
 package br.com.pucgo.perguntaai;
 
+import br.com.pucgo.perguntaai.models.User;
+import br.com.pucgo.perguntaai.repositories.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 class PerguntaaiBackendApplicationTests {
 
+	UserRepository userRepository;
 	@Test
-	void contextLoads() {
+	void mustResgisterUser() {
+		final User registerUser = User.builder()
+				.name("Aluno Teste")
+				.email("alunoteste@puc.com.br")
+				.course("ADS")
+				.password("123456")
+				.build();
+
+		userRepository.save(registerUser);
+		assertNotNull(userRepository);
 	}
 
 }

--- a/src/test/java/br/com/pucgo/perguntaai/PerguntaaiBackendApplicationTests.java
+++ b/src/test/java/br/com/pucgo/perguntaai/PerguntaaiBackendApplicationTests.java
@@ -21,29 +21,6 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 class PerguntaaiBackendApplicationTests {
 
-	@Mock
-	private UserRepository userRepository;
-	@InjectMocks
-	private UserController userController;
-	@Test
-	void mustResgisterUser() {
-		final UserForm registerUserForm = UserForm.builder()
-				.name("Aluno Teste")
-				.email("alunoteste@puc.com.br")
-				.course("ADS")
-				.password("123456")
-				.build();
 
-		User registerUser = registerUserForm.convert();
-
-		when(userRepository.save(ArgumentMatchers.any(User.class))).thenReturn(registerUser);
-
-
-		UriComponentsBuilder uriComponents = UriComponentsBuilder.fromUriString("localhost:8081/api/v1/user/register/{id}");
-
-		ResponseEntity<UserDto> userCreated = userController.register(registerUserForm, uriComponents);
-		assertThat(userCreated.getBody().getName()).isSameAs(registerUserForm.getName());
-		assertNotNull(userCreated);
-	}
 
 }


### PR DESCRIPTION
## O quê?
- Rota de Cadastro

## Por quê?
- Para poder cadastrar usuários com nome, e-mail, curso e senha

## Obs.:
- Possui Bug ao fazer o post, a API retorna que os campos enviados estão vazios.
