### PR TITLE
Melhoria da resposta de listar e detalhar tópico.

### DIFF
--- a/src/main/java/br/com/pucgo/perguntaai/controllers/v1/TopicsController.java
+++ b/src/main/java/br/com/pucgo/perguntaai/controllers/v1/TopicsController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/br/com/pucgo/perguntaai/models/DTO/TopicDto.java
+++ b/src/main/java/br/com/pucgo/perguntaai/models/DTO/TopicDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class TopicDto {
@@ -20,6 +21,7 @@ public class TopicDto {
     private AvatarOptions avatar;
     private String name;
     private final TopicStatus status;
+    private final List<String> tags;
 
 
     public TopicDto(Topic topic) {
@@ -32,6 +34,7 @@ public class TopicDto {
         this.totalOfAnswers = topic.getAnswers().size();
         this.avatar = topic.getAuthor().getAvatarOptions();
         this.name = topic.getAuthor().getName();
+        this.tags = topic.getTags();
     }
 
     public static Page<TopicDto> convert(Page<Topic> topics) {

--- a/src/main/java/br/com/pucgo/perguntaai/models/DTO/TopicDtoDetails.java
+++ b/src/main/java/br/com/pucgo/perguntaai/models/DTO/TopicDtoDetails.java
@@ -15,6 +15,7 @@ public class TopicDtoDetails {
     private final Long id;
     private final String message;
     private final LocalDateTime creationDate;
+    private final Long authorId;
     private final String authorName;
     private final String title;
     private final AvatarOptions avatar;
@@ -27,6 +28,7 @@ public class TopicDtoDetails {
         this.id = topic.getId();
         this.message = topic.getMessage();
         this.creationDate = topic.getCreationDate();
+        this.authorId = topic.getAuthor().getId();
         this.authorName = topic.getAuthor().getName();
         this.status = topic.getStatus();
         this.title = topic.getTitle();


### PR DESCRIPTION
## O quê?
- Adição do authorId no retorno da rota do tópico detalhado
- Adição da lista de tags nos tópicos, na rota de listar tópicos

## Por quê?
- Pedido do front

## Obs.:
-
![image](https://user-images.githubusercontent.com/61026112/145439331-581bb9c4-9011-445b-a0ce-d0b3c91c7742.png)
![image](https://user-images.githubusercontent.com/61026112/145439336-a073adfc-6274-4ebd-ac14-246f301f129e.png)

