### PR TITLE
adição auhtorId da answer na resposta da rota de detalhar tópicos

### DIFF
--- a/src/main/java/br/com/pucgo/perguntaai/models/DTO/AnswerDto.java
+++ b/src/main/java/br/com/pucgo/perguntaai/models/DTO/AnswerDto.java
@@ -15,6 +15,7 @@ public class AnswerDto {
     private final Long id;
     private final String message;
     private final LocalDateTime creationDate;
+    private final Long authorId;
     private final String authorName;
     private final AvatarOptions authorAvatar;
     private final int answerLikes;
@@ -24,6 +25,7 @@ public class AnswerDto {
         this.id = answer.getId();
         this.message = answer.getMessage();
         this.creationDate = answer.getCreationDate();
+        this.authorId = answer.getAuthor().getId();
         this.authorName = answer.getAuthor().getName();
         this.authorAvatar = answer.getAuthor().getAvatarOptions();
         this.answerLikes = answer.getAnswerLike();


### PR DESCRIPTION
## O quê?
- Adição auhtorId da answer no json de resposta, na rota de detalhar tópicos.

## Por quê?
- Pedido do front

## Obs.:
-
![image](https://user-images.githubusercontent.com/61026112/145655993-301322db-c30d-428f-9274-eef5ede3921c.png)

